### PR TITLE
Check staff status against logged in user instead the user being hijacked

### DIFF
--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -47,7 +47,7 @@ def login_user(request, user):
     if not request.user.is_superuser:
         if getattr(settings, "ALLOW_STAFF_TO_HIJACKUSER", False):
             # staff allowed, so check if user is staff
-            if not user.is_staff:
+            if not request.user.is_staff:
                 raise PermissionDenied
         else:
             # if user is not super user / staff he should be redirected to the admin login


### PR DESCRIPTION
The code gave permission denied if the current user had staff status as this code
checks against the user that is being hijacked instead of the user hijacking.