### PR TITLE
Add setting to choose which user attributes can be used for hijacking a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ For advanced superusers, users can be hijacked directly from the address bar by 
 * example.com/hijack/email/``email-address``
 * example.com/hijack/username/``username``
 
+### Specify which user attributes are allowed to hijack on
+By default all of the above methods (user id, email and username) are allowed. If you want to allow only a subset of these
+you can set ALLOWED_HIJACKING_USER_ATTRIBUTES in your project settings. This will disable the other endpoints.
+The settings take a list of methods to allow, you can select
+from:
+
+* user_ui
+* email
+* username
+
+NOTE: The link on the admin page will change in the order listed above. Say that you have enabled *username* and *email* then
+the users email will be used for the hijack link in on the admin page.
 
 ### Notify superusers when working behalf of another user
 This option warns the superuser when working with another user as initally logged in. To activate this option perform
@@ -153,6 +165,9 @@ All configuration settings with their default value and description
     
     # Where to go when you hijack someone; default equals the LOGIN_REDIRECT_URL; which has the default '/accounts/profile/'
     REVERSE_HIJACK_LOGIN_REDIRECT_URL = LOGIN_REDIRECT_URL
+    
+    # Which methods of hijacking a user is allowed; default = ('user_id', 'email', 'username')
+    ALLOWED_HIJACKING_USER_ATTRIBUTES = ('user_id', 'email', 'username')
 
 
 ## Signals

--- a/hijack/admin.py
+++ b/hijack/admin.py
@@ -9,7 +9,16 @@ from django.core.urlresolvers import reverse
 class HijackUserAdminMixin(object):
 
     def hijack_field(self, obj):
-        return '<a href="%s" class="button">Hijack %s</a>' % (reverse('login_with_id', args=(obj.id,)), obj)
+        hijack_methods = getattr(settings, 'ALLOWED_HIJACKING_USER_ATTRIBUTES', ('login_with_id',))
+
+        if 'login_with_id' in hijack_methods:
+            hijack_url = reverse('login_with_id', args=(obj.id,))
+        elif 'login_with_email' in hijack_methods:
+            hijack_url = reverse('login_with_email', args=(obj.email,))
+        else:
+            hijack_url = reverse('login_with_username', args=(obj.username,))
+
+        return '<a href="%s" class="button">Hijack %s</a>' % (hijack_url, obj)
     hijack_field.allow_tags = True
     hijack_field.short_description = 'Hijack User'
 

--- a/hijack/urls.py
+++ b/hijack/urls.py
@@ -3,12 +3,24 @@ from django.conf import settings
 
 urlpatterns = patterns('hijack.views',
     url(r'^release-hijack/$', 'release_hijack', name='release_hijack'),
-    url(r'^email/(?P<email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/$', 'login_with_email', name='login_with_email'),
-    url(r'^username/(?P<username>\w+)/$', 'login_with_username', name='login_with_username'),
-    url(r'^(?P<user_id>\w+)/$', 'login_with_id', name='login_with_id'),
 )
 
 if getattr(settings, "HIJACK_NOTIFY_ADMIN", False):
     urlpatterns += patterns('hijack.views',
         url(r'^disable-hijack-warning/$', 'disable_hijack_warning', name='disable_hijack_warning'),
+)
+
+hijacking_user_attributes = getattr(settings, "ALLOWED_HIJACKING_USER_ATTRIBUTES", False)
+
+if not hijacking_user_attributes or 'email' in hijacking_user_attributes:
+    urlpatterns += patterns('hijack.views',
+        url(r'^email/(?P<email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/$', 'login_with_email', name='login_with_email')
+    )
+if not hijacking_user_attributes or 'username' in hijacking_user_attributes:
+    urlpatterns += patterns('hijack.views',
+        url(r'^username/(?P<username>\w+)/$', 'login_with_username', name='login_with_username'),
+    )
+if not hijacking_user_attributes or 'user_id' in hijacking_user_attributes:
+    urlpatterns += patterns('hijack.views',
+        url(r'^(?P<user_id>\w+)/$', 'login_with_id', name='login_with_id')
     )


### PR DESCRIPTION
This adds a ALLOWED_HIJACKING_USER_ATTRIBUTES settings allowing developers to specify which user attributes can be used when hijacking a user. The main reason I created this was to remove unnecessary urls. 

For instance in my case for instance I do not have a username for my user, so the URL for hijacking via username is pointless and only clutters my URLs. The defaults stay the same so that no settings needs to be changed for existing setups, in other words this is hopefully non breaking change.