### PR TITLE
Only include 'disable-hijack-warning' url if HIJACK_NOTIFY_ADMIN is enabled

### DIFF
--- a/hijack/tests/test_settings.py
+++ b/hijack/tests/test_settings.py
@@ -22,6 +22,7 @@ DATABASES = {
 #LOGIN_REDIRECT_URL = 'hello'
 HIJACK_LOGIN_REDIRECT_URL = "/hello"
 REVERSE_HIJACK_LOGIN_REDIRECT_URL = '/admin/auth/user/'
+HIJACK_NOTIFY_ADMIN = True
 
 ROOT_URLCONF = 'hijack.tests.urls'
 

--- a/hijack/urls.py
+++ b/hijack/urls.py
@@ -1,9 +1,14 @@
 from compat import patterns, url
+from django.conf import settings
 
 urlpatterns = patterns('hijack.views',
-    url(r'^disable-hijack-warning/$', 'disable_hijack_warning', name='disable_hijack_warning'),
     url(r'^release-hijack/$', 'release_hijack', name='release_hijack'),
     url(r'^email/(?P<email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/$', 'login_with_email', name='login_with_email'),
     url(r'^username/(?P<username>\w+)/$', 'login_with_username', name='login_with_username'),
     url(r'^(?P<userId>\w+)/$', 'login_with_id', name='login_with_id'),
 )
+
+if getattr(settings, "HIJACK_NOTIFY_ADMIN", False):
+    urlpatterns += patterns('hijack.views',
+        url(r'^disable-hijack-warning/$', 'disable_hijack_warning', name='disable_hijack_warning'),
+    )


### PR DESCRIPTION
The reason for this is the same as arteria/django-hijack#43 , to minimize extra URLs when a settings is not enabled.