### PR TITLE
Use a more liberal/naive approach to regex checking for an email

### DIFF
--- a/hijack/urls.py
+++ b/hijack/urls.py
@@ -14,7 +14,7 @@ hijacking_user_attributes = getattr(settings, "ALLOWED_HIJACKING_USER_ATTRIBUTES
 
 if not hijacking_user_attributes or 'email' in hijacking_user_attributes:
     urlpatterns += patterns('hijack.views',
-        url(r'^email/(?P<email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/$', 'login_with_email', name='login_with_email')
+        url(r'^email/(?P<email>[^@]+@[^@]+\.[^@]+)/$', 'login_with_email', name='login_with_email')
     )
 if not hijacking_user_attributes or 'username' in hijacking_user_attributes:
     urlpatterns += patterns('hijack.views',


### PR DESCRIPTION
The problem with the old method is that it does not support
- Internationalized TLDs, domains or users, such as .xn--4gbrim domains
- Geographic TLDs, such as .europe
- ICANN-era TLDs, such as .audio and .clothing

The new regex still matches <anything>@<anything>.<anything> so we still have some mail
characteristics in the URL.