### PR TITLE
fixed login with id when obj has no id attribute

### DIFF
--- a/hijack/admin.py
+++ b/hijack/admin.py
@@ -12,7 +12,7 @@ class HijackUserAdminMixin(object):
         hijack_methods = getattr(settings, 'ALLOWED_HIJACKING_USER_ATTRIBUTES', ('login_with_id',))
 
         if 'login_with_id' in hijack_methods:
-            hijack_url = reverse('login_with_id', args=(obj.id,))
+            hijack_url = reverse('login_with_id', args=(obj.pk,))
         elif 'login_with_email' in hijack_methods:
             hijack_url = reverse('login_with_email', args=(obj.email,))
         else:


### PR DESCRIPTION
when using login with id it tries to get obj.id (object is the User object).
However not all user models have an id available. 

Later on it searches for the user using the PK. So this change is fine for people who use id as a reference since it should be the same as PK. 