### PR TITLE
PR for issue #50: Added ALLOW_STAFF_TO_HIJACK_STAFF_USER setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ follow these steps:
 ### Allow staff members to hijack other users
 This option allows staff members to hijack other users. In your project settings set ``ALLOW_STAFF_TO_HIJACKUSER`` to ``True``. The default is False.
 
-Staff members are **not allowed** to hijack admins/superusers. 
+Staff members are **not allowed** to hijack other staff members or admins/superusers.
+
+If you want staff members to be able hijack other staff members you should set ``ALLOW_STAFF_TO_HIJACK_STAFF_USER`` to ``True``. The default is also False.
 
 ### Django 1.4 - 1.8 compatibility with [django-compat](https://github.com/arteria/django-compat)
 
@@ -165,6 +167,9 @@ All configuration settings with their default value and description
     
     # Allow staff users to hijack; default = False
     ALLOW_STAFF_TO_HIJACKUSER = False
+
+    # Allow staff users to hijack other staff users; default = False
+    ALLOW_STAFF_TO_HIJACK_STAFF_USER = False
     
     # Where to go when you hijack someone; default equals the LOGIN_REDIRECT_URL; which has the default '/accounts/profile/'
     REVERSE_HIJACK_LOGIN_REDIRECT_URL = LOGIN_REDIRECT_URL

--- a/hijack/tests/hijack_tests.py
+++ b/hijack/tests/hijack_tests.py
@@ -120,6 +120,19 @@ class HijackTests(TestCase):
         else:
             self.assertTrue('name="this_is_the_login_form"' in  str(response.content))
 
+    def test_staff_to_staff_hijacking_without_proper_setting(self):
+        self.client.login(username='Test1', password='Test1 pw')
+        with self.settings(ALLOW_STAFF_TO_HIJACKUSER=True):
+            response = self.client.get('/hijack/5/', follow=True)
+            self.assertEqual(response.status_code, 403)
+
+    def test_staff_to_staff_hijacking_with_proper_setting(self):
+        self.client.login(username='Test1', password='Test1 pw')
+        with self.settings(ALLOW_STAFF_TO_HIJACKUSER=True,
+                           ALLOW_STAFF_TO_HIJACK_STAFF_USER=True):
+            response = self.client.get('/hijack/5/', follow=True)
+            self.assertEqual(response.status_code, 200)
+
     def test_hijack_admin(self):
         from hijack.admin import HijackUserAdmin
 


### PR DESCRIPTION
Added ALLOW_STAFF_TO_HIJACK_STAFF_USER setting, added tests and created a separate function for the permission check.

Keep in mind that the permission check is more strict now. If you want to allow staff members to hijack other staff members you need to add this setting explicitly.