### PR TITLE
Unicode in user name when generating hijack URL

### DIFF
--- a/hijack/admin.py
+++ b/hijack/admin.py
@@ -24,7 +24,7 @@ class HijackUserAdminMixin(object):
                 "`ALLOWED_HIJACKING_USER_ATTRIBUTES` needs to be "
                 "properly defined")
 
-        return format_html('<a href="{}" class="button">Hijack {}</a>',
+        return format_html(u'<a href="{}" class="button">Hijack {}</a>',
                            hijack_url, obj)
 
     hijack_field.allow_tags = True


### PR DESCRIPTION
In a Python 2 environment, the format string isn't unicode and so it can cause a UnicodeEncodeError if the user's display name contains unicode characters (for example: Luis García).