### PR TITLE
PR for issue #72. Hijack with RemoteUser

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ Add the ``hijack`` URLs to your ``urls.py``
         url(r'^hijack/', include('hijack.urls')),
     )
 
+To work with `REMOTE_USER` just place `'hijack.middleware.HijackRemoteUserMiddleware',`
+between `django.contrib.auth.middleware.AuthenticationMiddleware` and `django.contrib.auth.middleware.RemoteUserMiddleware`
+in `settings.MIDDLEWARE_CLASSES`
+
+    MIDDLEWARE_CLASSES = (
+        ...,
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'hijack.middleware.HijackRemoteUserMiddleware',
+        'django.contrib.auth.middleware.RemoteUserMiddleware',
+        ...,
+    )
+
+
 ## Usage and modes
 
 There are different possibilities to hijack a user and communicate with users.
@@ -199,7 +212,6 @@ You can catch a signal when a superuser logs in as another user. Here is an exam
 * Support for named URLs for the hijack button.
 * Handle signals in ``release_hijack(..)``, currently the signals are only triggered in ``login_user(..)`` and ``logout_user(..)``.
 * Graceful support for custom user models that do not feature username / email
-* RemoteUserMiddleware does not work currently, see [#72](https://github.com/arteria/django-hijack/issues/72) 
 
 
 ## FAQ, troubleshooting and hints

--- a/hijack/middleware.py
+++ b/hijack/middleware.py
@@ -1,0 +1,20 @@
+class HijackRemoteUserMiddleware(object):
+    """
+    Middleware for hijack RemoteUser. One must place this middleware between
+    'django.contrib.auth.middleware.AuthenticationMiddleware' and
+    'django.contrib.auth.middleware.RemoteUserMiddleware' in MIDDLEWARE_CLASSES
+
+    Just makes remote user same as hijacked
+    """
+    header = "REMOTE_USER"
+
+    def process_request(self, request):
+        is_hijacked = request.session.get('is_hijacked_user', False)
+        remote_username = request.META.get(self.header, None)
+        if not is_hijacked or not remote_username:
+            return
+        # Ok, we hijacked and remote. Just assign hijacked user to remote
+        if request.user.is_authenticated():
+            username = request.user.get_username()
+            if username != remote_username:
+                request.META[self.header] = username


### PR DESCRIPTION
Fix of Incompatibility if used several user backends and RemoteUserMiddleware
To use place
`'hijack.middleware.HijackRemoteUserMiddleware',`
between of `django.contrib.auth.middleware.AuthenticationMiddleware` and `django.contrib.auth.middleware.RemoteUserMiddleware` in `settings.MIDDLEWARE_CLASSES`