### PR TITLE
Fix hide button to redirects correct full path 

### DIFF
--- a/hijack/templates/hijack/notifications.html
+++ b/hijack/templates/hijack/notifications.html
@@ -2,5 +2,5 @@
 <div id="hijacked-warning" >
     <span style="padding-top: 4px; float: left;"><b>You're currently working on behalf of {{ request.user }}.</b></span>
     <span style="float: right; margin-right: 15px;"><a href="{% url 'release_hijack' %}" class="django-hijack-button">release {{ request.user }}</a>
-    <a href="{% url 'disable_hijack_warning' %}?next={{ request.path_info }}" class="django-hijack-button">hide</a></span>
+    <a href="{% url 'disable_hijack_warning' %}?next={{ request.path }}" class="django-hijack-button">hide</a></span>
 </div>


### PR DESCRIPTION
The current hide button does not work when there is a path prefix because it uses 'request.path'.  Replacing this with 'request.path_info to get proper full path.