### PR TITLE
Do not allow staff to hijack admins

### DIFF
--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -65,6 +65,8 @@ def can_hijack(hijacker, hijacked):
 
     Staff users can never hijack superusers.
     """
+    if hijacked.is_superuser and not hijacker.is_superuser:
+        return False
 
     if hijacker.is_superuser:
         return True

--- a/hijack/tests/hijack_tests.py
+++ b/hijack/tests/hijack_tests.py
@@ -162,6 +162,13 @@ class HijackTests(TestCase):
             response = self.client.get('/hijack/5/', follow=True)
             self.assertEqual(response.status_code, 200)
 
+    def test_staff_to_admin_hijacking_never_allowed(self):
+        # a staff user should never hijack an admin
+        self.client.login(username='Test1', password='Test1 pw')
+        with self.settings(ALLOW_STAFF_TO_HIJACK_STAFF_USER=True):
+            response = self.client.get('/hijack/1/', follow=True)
+            self.assertEqual(response.status_code, 403)
+
     def test_hijack_admin(self):
         from hijack.admin import HijackUserAdmin
 


### PR DESCRIPTION
with the `ALLOW_STAFF_TO_HIJACK_STAFF_USER` setting set to `True` staff members were able to hijack admins if they were also staff.