### PR TITLE
User can now also be hijacked without specifying what piece of information you are providing, older method still remains

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ For advanced superusers, users can be hijacked directly from the address bar by 
 * example.com/hijack/email/``email-address``
 * example.com/hijack/username/``username``
 
+If you do not want to specify what piece of information of the user you are providing, you can also simply hijack by typing ``email`` and ``username`` right after ``hijack/``:
+
+* example.com/hijack/``email-address``
+* example.com/hijack/``username``
+
 ### Specify which user attributes are allowed to hijack on
 By default all of the above methods (user id, email and username) are allowed. If you want to allow only a subset of these
 you can set ALLOWED_HIJACKING_USER_ATTRIBUTES in your project settings. This will disable the other endpoints.

--- a/hijack/urls.py
+++ b/hijack/urls.py
@@ -19,6 +19,10 @@ if not hijacking_user_attributes or 'email' in hijacking_user_attributes:
                             url(r'^email/(?P<email>[^@]+@[^@]+\.[^@]+)/$',
                                 view='login_with_email',
                                 name='login_with_email', ), )
+    urlpatterns += patterns('hijack.views',
+                            url(r'^(?P<email>[^@]+@[^@]+\.[^@]+)/$',
+                                view='login_with_email',
+                                name='login_with_email', ), )
 if not hijacking_user_attributes or 'username' in hijacking_user_attributes:
     urlpatterns += patterns('hijack.views',
                             url(r'^username/(?P<username>\w+)/$',

--- a/hijack/views.py
+++ b/hijack/views.py
@@ -18,8 +18,9 @@ def login_with_id(request, user_id):
     try:
         user_id = int(user_id)
     except ValueError:
-        return HttpResponseBadRequest('user_id must be an integer value.')
-    user = get_object_or_404(get_user_model(), pk=user_id)
+        user = get_object_or_404(get_user_model(), username=user_id)
+    else:
+        user = get_object_or_404(get_user_model(), pk=user_id)
     return login_user(request, user)
 
 


### PR DESCRIPTION
Most of the times developer does not want to care about specifying whether user has to be hijacked through user-id/username/email. I have sorted out this problem. Now you can provide either of user-id/username/email after '/hijack/' and the masquerading will be implemented. Older method still remains about providing username after '/hijack/username/' and email-address after '/hijack/email/'.

Hope this helps!