### PR TITLE
fix UUID serialization issue at login_user

### DIFF
--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -102,7 +102,7 @@ def check_hijack_permission(request, user):
 
 def login_user(request, user):
     ''' hijack mechanism '''
-    hijack_history = [request.user.pk]
+    hijack_history = [request.user._meta.pk.value_to_string(request.user)]
     if request.session.get('hijack_history'):
         hijack_history = request.session['hijack_history'] + hijack_history
 


### PR DESCRIPTION
Currently if you use the UUID field for the user primary key then while logging in you get the traceback

UUID('85410f5f-ec82-4148-ba78-5be5a79f0fb1') is not JSON serializable

This happens because:
https://github.com/arteria/django-hijack/blob/master/hijack/helpers.py#L117
Once the session serializer finds a UUID field it fails.

The problem is also described here:
https://code.djangoproject.com/ticket/24161

The fix is also from Djangos current code:
https://github.com/timgraham/django/blob/0f7f5bc9e7a94ab91c2b3db29ef7cf000eff593f/django/contrib/auth/__init__.py#L111