### PR TITLE
Changed regex for userid to allow negative IDs

### DIFF
--- a/hijack/urls.py
+++ b/hijack/urls.py
@@ -25,6 +25,6 @@ if not hijacking_user_attributes or 'username' in hijacking_user_attributes:
                                 view='login_with_username',
                                 name='login_with_username', ), )
 if not hijacking_user_attributes or 'user_id' in hijacking_user_attributes:
-    urlpatterns += patterns('hijack.views', url(r'^(?P<user_id>\w+)/$',
+    urlpatterns += patterns('hijack.views', url(r'^(?P<user_id>[\w-]+)/$',
                                                 view='login_with_id',
                                                 name='login_with_id', ), )


### PR DESCRIPTION
django-guardian needs a anonymous user, which has a user-id of -1 in the suggested default config:
> https://github.com/django-guardian/django-guardian#configuration

This patch adjusts the regex in the urls.py to allow for this negative userid. Without this patch rendering the userlist in the admin fails.