### PR TITLE
FIX Error authenticate method not defined

### DIFF
--- a/hijack/middleware.py
+++ b/hijack/middleware.py
@@ -18,3 +18,6 @@ class HijackRemoteUserMiddleware(object):
             username = request.user.get_username()
             if username != remote_username:
                 request.META[self.header] = username
+                
+    def authenticate(self, *args, **kwargs):
+        return None


### PR DESCRIPTION
just because the HijackRemoteUserMiddleware don't have the authenticate method.