### PR TITLE
Using Django's PK for hijacked

### DIFF
--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -48,7 +48,7 @@ def release_hijack(request):
         except KeyError:
             pass
     request.session.modified = True
-    hijack_ended.send(sender=None, hijacker_id=hijacker.id, hijacked_id=hijacked.id)
+    hijack_ended.send(sender=None, hijacker_id=hijacker.pk, hijacked_id=hijacked.pk)
     return redirect_to_next(request, default_url=hijack_settings.HIJACK_LOGOUT_REDIRECT_URL)
 
 


### PR DESCRIPTION
Not all user models have "id" as their primary key. Django's pk value handles this more elegantly. This is already being done on line 114 and 127.