### PR TITLE
UnicodeDecodeError during pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ dev_requires = ['flake8', ]
 
 def read(fname):
     try:
-        return open(os.path.join(os.path.dirname(__file__), fname)).read()
+        return open(os.path.join(os.path.dirname(__file__), fname), 
+                    'r', 
+                    encoding='utf8').read()
     except IOError:
         return ''
 


### PR DESCRIPTION
We had to do export `LC_ALL=env_US.utf8` to get things working, this fixes that.

```
Collecting django-hijack==2.0.2 (from -r requirements/common.txt (line 29))
  Downloading django-hijack-2.0.2.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-lph62f8b/django-hijack/setup.py", line 47, in <module>
        long_description=read('README.md'),
      File "/tmp/pip-build-lph62f8b/django-hijack/setup.py", line 39, in read
        return open(os.path.join(os.path.dirname(__file__), fname)).read()
      File "/home/sendcloud/releases/master/virtualenv/3.4_5c623d701cdd1926bc2bcc4753d85a9e/lib/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 930: ordinal not in range(128)
```