### PR TITLE
Not passing context to render

### DIFF
--- a/hijack/admin.py
+++ b/hijack/admin.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext as _
 from hijack import settings as hijack_settings
 
 import django
-if django.VERSION <= (1, 7):
+if django.VERSION < (1, 8):
     from django.template import Context
 
 
@@ -29,7 +29,8 @@ class HijackUserAdminMixin(object):
             'hijack_url': hijack_url,
             'username': str(obj),
         }
-        if django.VERSION <= (1, 7):
+        import django
+        if django.VERSION < (1, 8):
             button_context = Context(button_context)
 
         return button_template.render(button_context)

--- a/hijack/admin.py
+++ b/hijack/admin.py
@@ -5,8 +5,12 @@ from django.contrib.auth.admin import UserAdmin
 from django.core.urlresolvers import reverse
 from django.template.loader import get_template
 from django.utils.translation import ugettext as _
-
 from hijack import settings as hijack_settings
+
+import django
+if django.VERSION <= (1, 7):
+    from django.template import Context
+
 
 
 class HijackUserAdminMixin(object):
@@ -25,6 +29,9 @@ class HijackUserAdminMixin(object):
             'hijack_url': hijack_url,
             'username': str(obj),
         }
+        if django.VERSION <= (1, 7):
+            button_context = Context(button_context)
+
         return button_template.render(button_context)
 
     hijack_field.allow_tags = True

--- a/hijack/admin.py
+++ b/hijack/admin.py
@@ -3,7 +3,6 @@ from compat import get_user_model
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.core.urlresolvers import reverse
-from django.template import Context
 from django.template.loader import get_template
 from django.utils.translation import ugettext as _
 
@@ -22,10 +21,10 @@ class HijackUserAdminMixin(object):
             hijack_url = reverse('login_with_username', args=(obj.username, ))
 
         button_template = get_template('hijack/admin_button.html')
-        button_context = Context({
+        button_context = {
             'hijack_url': hijack_url,
             'username': str(obj),
-        })
+        }
         return button_template.render(button_context)
 
     hijack_field.allow_tags = True


### PR DESCRIPTION
render function already assumes dict will be converted to context in Django 1.10. #104 

