### PR TITLE
Changed the ugettext to ugettext_lazy

### DIFF
--- a/hijack/admin.py
+++ b/hijack/admin.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.core.urlresolvers import reverse
 from django.template.loader import get_template
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django import VERSION
 
 from hijack import settings as hijack_settings


### PR DESCRIPTION
This fixes the error message about form plural

ValueError: plural forms expression could be dangerous