### PR TITLE
Make button_template in to a setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 
 # Notification bar
-The template used for the notification bar is named "hijack/notifications.html", or "hijack/notifications_bootstrap.html"
+The template used for the notification bar is named "hijack/notifications.html", or "hijack/notifications_bootstrap.html" 
 if Bootstrap is enabled.
 
 ## Bootstrap
@@ -8,7 +8,7 @@ If your project uses Bootstrap, you may want to set `HIJACK_USE_BOOTSTRAP = True
 Django Hijack will use a Bootstrap notification bar that does not overlap with the default navbar.
 
 ## Disabling the notification bar
-You can temporarily disable the notification bar by setting `HIJACK_DISPLAY_WARNING = False`.
+You can temporarily disable the notification bar by setting `HIJACK_DISPLAY_WARNING = False`. 
 
 # Permissions
 By default, only superusers are allowed to hijack other users.
@@ -21,8 +21,8 @@ If you want staff to be able to hijack other staff as well, enable `HIJACK_AUTHO
 Note that there is no option to authorize staff members to hijack superusers as this would undermine the distinction between staff users and superusers.
 
 ## Custom authorization function
-Advanced Django developers might want to define their own check whether a user may hijack another user. This can be achieved by
-setting `HIJACK_AUTHORIZATION_CHECK` to the dotted path of a function which accepts two User
+Advanced Django developers might want to define their own check whether a user may hijack another user. This can be achieved by 
+setting `HIJACK_AUTHORIZATION_CHECK` to the dotted path of a function which accepts two User 
 objects – `hijacker` and `hijacked` – and returns a Boolean value. Example:
 
 ```python
@@ -43,12 +43,12 @@ def my_authorization_check(hijacker, hijacked):
 ```
 
 **Warning: The setting `HIJACK_AUTHORIZATION_CHECK` overrides the other hijack authorization settings. Defining a custom authorization function can have dangerous
-effects on your application's authorization system. Potentially, it might allow any user to impersonate
+effects on your application's authorization system. Potentially, it might allow any user to impersonate 
 any other user and to take advantage of all their permissions.**
 
 ## Custom view decorator
-Django Hijack's views are decorated by Django's `staff_member_required` decorator. If you have written your own
-authorization function, or haven't installed `django.contrib.admin`, you may want to override this behaviour by
+Django Hijack's views are decorated by Django's `staff_member_required` decorator. If you have written your own 
+authorization function, or haven't installed `django.contrib.admin`, you may want to override this behaviour by 
 setting `HIJACK_DECORATOR` to the dotted path of a custom decorator. Example:
 
 ```python

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 
 # Notification bar
-The template used for the notification bar is named "hijack/notifications.html", or "hijack/notifications_bootstrap.html" 
+The template used for the notification bar is named "hijack/notifications.html", or "hijack/notifications_bootstrap.html"
 if Bootstrap is enabled.
 
 ## Bootstrap
@@ -8,7 +8,7 @@ If your project uses Bootstrap, you may want to set `HIJACK_USE_BOOTSTRAP = True
 Django Hijack will use a Bootstrap notification bar that does not overlap with the default navbar.
 
 ## Disabling the notification bar
-You can temporarily disable the notification bar by setting `HIJACK_DISPLAY_WARNING = False`. 
+You can temporarily disable the notification bar by setting `HIJACK_DISPLAY_WARNING = False`.
 
 # Permissions
 By default, only superusers are allowed to hijack other users.
@@ -21,8 +21,8 @@ If you want staff to be able to hijack other staff as well, enable `HIJACK_AUTHO
 Note that there is no option to authorize staff members to hijack superusers as this would undermine the distinction between staff users and superusers.
 
 ## Custom authorization function
-Advanced Django developers might want to define their own check whether a user may hijack another user. This can be achieved by 
-setting `HIJACK_AUTHORIZATION_CHECK` to the dotted path of a function which accepts two User 
+Advanced Django developers might want to define their own check whether a user may hijack another user. This can be achieved by
+setting `HIJACK_AUTHORIZATION_CHECK` to the dotted path of a function which accepts two User
 objects – `hijacker` and `hijacked` – and returns a Boolean value. Example:
 
 ```python
@@ -43,12 +43,12 @@ def my_authorization_check(hijacker, hijacked):
 ```
 
 **Warning: The setting `HIJACK_AUTHORIZATION_CHECK` overrides the other hijack authorization settings. Defining a custom authorization function can have dangerous
-effects on your application's authorization system. Potentially, it might allow any user to impersonate 
+effects on your application's authorization system. Potentially, it might allow any user to impersonate
 any other user and to take advantage of all their permissions.**
 
 ## Custom view decorator
-Django Hijack's views are decorated by Django's `staff_member_required` decorator. If you have written your own 
-authorization function, or haven't installed `django.contrib.admin`, you may want to override this behaviour by 
+Django Hijack's views are decorated by Django's `staff_member_required` decorator. If you have written your own
+authorization function, or haven't installed `django.contrib.admin`, you may want to override this behaviour by
 setting `HIJACK_DECORATOR` to the dotted path of a custom decorator. Example:
 
 ```python
@@ -89,6 +89,8 @@ In addition, you should explicitly set `HIJACK_DISPLAY_ADMIN_BUTTON = False` in 
 # Settings overview
 ## `HIJACK_DISPLAY_ADMIN_BUTTON`
 Hide or display the "Hijack" buttons in the admin backend. Default: `True`.
+## `HIJACK_BUTTON_TEMPLATE`
+Path to template for the "Hijack" buttons in the admin backend. Default: `'hijack/admin_button.html'`
 ## `HIJACK_DISPLAY_WARNING`
 Hide or display the yellow notificiation bar show to hijackers. Default: `True`.
 ## `HIJACK_USE_BOOTSTRAP`

--- a/hijack/admin.py
+++ b/hijack/admin.py
@@ -24,7 +24,7 @@ class HijackUserAdminMixin(object):
         else:
             hijack_url = reverse('login_with_username', args=(obj.username, ))
 
-        button_template = get_template('hijack/admin_button.html')
+        button_template = get_template(hijack_settings.HIJACK_BUTTON_TEMPLATE)
         button_context = {
             'hijack_url': hijack_url,
             'username': str(obj),

--- a/hijack/settings.py
+++ b/hijack/settings.py
@@ -52,6 +52,12 @@ SETTINGS = (
         'default': False,
         'legacy_name': None,
     },
+    {
+        'name': 'HIJACK_BUTTON_TEMPLATE',
+        'default': 'hijack/admin_button.html',
+        'legacy_name': None,
+    },
+
 )
 
 for setting in SETTINGS:
@@ -61,3 +67,5 @@ for setting in SETTINGS:
         default = setting['default']
     value = getattr(django_settings, setting['name'], default)
     globals()[setting['name']] = value
+
+HIJACK_BUTTON_TEMPLATE = 'hijack/admin_button.html'

--- a/hijack/settings.py
+++ b/hijack/settings.py
@@ -67,5 +67,3 @@ for setting in SETTINGS:
         default = setting['default']
     value = getattr(django_settings, setting['name'], default)
     globals()[setting['name']] = value
-
-HIJACK_BUTTON_TEMPLATE = 'hijack/admin_button.html'


### PR DESCRIPTION
When intergrating with non-standard django-admin skins (I'm using django-suit specifically) it would be nice to able to customize the  #button template without having to rewrite the `HijackUserAdminMixin `entirely.

The easiest way that I see is to make the location of `button_template `into a setting - which defaults to what the current default is.