### PR TITLE
Avoid "KeyError: 'request'" when other templates error

### DIFF
--- a/hijack/templatetags/hijack_tags.py
+++ b/hijack/templatetags/hijack_tags.py
@@ -19,7 +19,7 @@ def hijackNotification(request):
 
 @register.simple_tag(takes_context=True)
 def hijack_notification(context):
-    request = context['request']
+    request = context.get('request')
     return _render_hijack_notification(request)
 
 


### PR DESCRIPTION
When there is another syntax or parsing error in the django template, the original stack trace is hidden because django hijack then crashes when rendering the template tag with "KeyError: 'request'" on that line.
It’s particularly annoying when running unit tests, so making this a bit more exception safe.