### PR TITLE
Avoid server error when rendering handler500

### DIFF
--- a/hijack/templatetags/hijack_tags.py
+++ b/hijack/templatetags/hijack_tags.py
@@ -29,9 +29,8 @@ def _render_hijack_notification(request):
     else:
         template_name = 'hijack/notifications.html'
     ans = ''
-    if all([
+    if request is not None and all([
         hijack_settings.HIJACK_DISPLAY_WARNING,
-        request,
         request.session.get('is_hijacked_user', False),
         request.session.get('display_hijack_warning', False),
     ]):


### PR DESCRIPTION
Following #119, it turns out the `all` statement called shortly after is now crashing, as it's evaluating all the statements (rather than stopping at the first False one), and therefore raising a "NoneType has no attribute session" when `request` is `None`.

It prevents us from serving the [custom 500 handler](https://docs.djangoproject.com/en/1.9/topics/http/views/#customizing-error-views) from Django, because our 500.html inherits from our base template which has the hijack template tag. Not sure if this was a known limitation, but this is new PR is fixing it.