### PR TITLE
Added a generic template filter to see if request is hijacked

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,16 @@ To set up the notification bar, add the following lines to your `base.html` or t
 If your project uses Bootstrap you may want to set `HIJACK_USE_BOOTSTRAP = True` in your project settings.
 Django Hijack will display a Bootstrap notification bar that does not overlap with the default navbar.
 
+### Generic template filter
+We also provide a generic template filter to check if you are currently hijacking a user. This is useful for displaying/hiding elements besides the notification bar.
+
+```html
+{% load hijack_tags %}
+{% if request|is_hijacked %}
+...
+{% endif %}
+```
+
 # Usage
 
 Superusers can hijack a user by by sending a POST request to a `/hijack/...` URL.

--- a/hijack/templatetags/hijack_tags.py
+++ b/hijack/templatetags/hijack_tags.py
@@ -46,3 +46,8 @@ def _render_hijack_notification(request):
 def can_hijack(hijacker, hijacked):
     check_authorization = import_string(hijack_settings.HIJACK_AUTHORIZATION_CHECK)
     return check_authorization(hijacker, hijacked)
+
+
+@register.filter
+def is_hijacked(request):
+    return request.session.get('is_hijacked_user', False)

--- a/hijack/tests/test_app/templates/hello.html
+++ b/hijack/tests/test_app/templates/hello.html
@@ -3,3 +3,6 @@ Notification tag:
 {% hijack_notification %}
 <h1>Hello</h1>
 <p>{{ user }}</p>
+{% if request|is_hijacked %}
+<p>You are hijacking this user</p>
+{% endif %}

--- a/hijack/tests/test_hijack.py
+++ b/hijack/tests/test_hijack.py
@@ -244,6 +244,14 @@ class HijackTests(BaseHijackTests):
         self.assertTrue('Notification tag' in str(response.content))
         self.assertTrue('hijacked-warning' in str(response.content))
 
+    def test_is_hijacked_filter(self):
+        response = self._hijack(self.user)
+        self.assertHijackSuccess(response)
+        response = self.client.get('/hello/')
+        print(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'You are hijacking this user')
+
     def test_notification_filter(self):
         response = self._hijack(self.user)
         self.assertHijackSuccess(response)


### PR DESCRIPTION
I found myself wanting to display/hide elements on the page that were not just the hijack notification. This simple template filter checks the session to see if the request is hijacked.

Ex: You might not want to muck up your google analytics data with requests that aren't from the actual user.

```html
{% load hijack_tags %}
{% if not request|is_hijacked %}
<script src="/js/google-analytics.js"></script>
{% endif %}
```
