### PR TITLE
mini-css-fix: avoid content to be hidden by the fixed notification warning.

### DIFF
--- a/hijack/static/hijack/hijack-styles.css
+++ b/hijack/static/hijack/hijack-styles.css
@@ -12,6 +12,8 @@
   font-weight: 600;
   text-align: center;
   position:fixed;
+  min-height: 50px;
+  height: auto;
   top: 0;
   left: 0;
   right: 0;
@@ -20,6 +22,11 @@
   border-bottom: 2px solid #ae9e49;
   font-size: 12px;
   font-family: sans-serif;
+}
+#hijacked-warning-wrapper::after {
+    height: 50px;
+    content: "";
+    display: block;
 }
 
 .hijacked-warning-bootstrap {

--- a/hijack/templates/hijack/notifications.html
+++ b/hijack/templates/hijack/notifications.html
@@ -1,6 +1,7 @@
 {% load url from compat %}
 {% load i18n %}
 
+<div id="hijacked-warning-wrapper">
 <div id="hijacked-warning" class="hijacked-warning hijacked-warning-default">
     <span style="padding-top: 4px; float: left;"><b>{% blocktrans with user=request.user%}You are currently working on behalf of {{ user }}.{% endblocktrans %}</b></span>
     <div class="hijacked-warning-controls hijacked-warning-controls-pull-right">
@@ -13,4 +14,5 @@
             <button type="submit" class="django-hijack-button-default">{% trans "hide" %}</button>
         </form>
     </div>
+</div>
 </div>


### PR DESCRIPTION
My content was hidden by the notification bar.
So I quickly assembled a fixed to "push" the masked content by 50px :
- added a "hijacked-warning-wrapper" div
- added some css properties.

Before:
<img width="549" alt="before-fix" src="https://cloud.githubusercontent.com/assets/18702503/20580031/0f6ccd38-b19e-11e6-9062-75bd1fd323a5.png">

After:
<img width="548" alt="after-fix" src="https://cloud.githubusercontent.com/assets/18702503/20580034/13070170-b19e-11e6-826a-ce0fc37fb3b5.png">


I Know there's a hide button, though it reloads the page, and I will remove this button on my project anyway.