### PR TITLE
Add link and badge to PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/arteria/django-hijack.svg?branch=master)](https://travis-ci.org/arteria/django-hijack)
 [![Stories in Ready](https://badge.waffle.io/arteria/django-hijack.png?label=ready&title=Ready)](https://waffle.io/arteria/django-hijack)
 [![Coverage Status](https://coveralls.io/repos/arteria/django-hijack/badge.svg?branch=master&service=github)](https://coveralls.io/github/arteria/django-hijack?branch=master)
+[![PyPI](https://img.shields.io/pypi/v/django-hijack.svg)](https://pypi.python.org/pypi/django-hijack)
 
 ![Screenshot of the notification seen while hijacking another user.](docs/hijacker-screenshot.png)
 


### PR DESCRIPTION
This is useful to be able to quickly check these things:

- Whether this package has been released on PyPI or not
- Which version number is the latest on PyPI
- Once you click on the link, you can verify what the PyPI package name is, for use with `pip`