### PR TITLE
add conditional to use is_authenticated property when django >= 1.10

### DIFF
--- a/hijack/middleware.py
+++ b/hijack/middleware.py
@@ -1,3 +1,5 @@
+import django
+
 class HijackRemoteUserMiddleware(object):
     """
     Middleware for hijack RemoteUser. One must place this middleware between
@@ -14,10 +16,14 @@ class HijackRemoteUserMiddleware(object):
         if not is_hijacked or not remote_username:
             return
         # Ok, we hijacked and remote. Just assign hijacked user to remote
-        if request.user.is_authenticated():
+        if django.VERSION >= (1, 10):
+            is_authenticated = request.user.is_authenticated
+        else:
+            is_authenticated = request.user.is_authenticated()
+        if is_authenticated:
             username = request.user.get_username()
             if username != remote_username:
                 request.META[self.header] = username
-                
+
     def authenticate(self, *args, **kwargs):
         return None

--- a/hijack/middleware.py
+++ b/hijack/middleware.py
@@ -1,5 +1,3 @@
-import django
-
 class HijackRemoteUserMiddleware(object):
     """
     Middleware for hijack RemoteUser. One must place this middleware between

--- a/hijack/middleware.py
+++ b/hijack/middleware.py
@@ -16,10 +16,10 @@ class HijackRemoteUserMiddleware(object):
         if not is_hijacked or not remote_username:
             return
         # Ok, we hijacked and remote. Just assign hijacked user to remote
-        if django.VERSION >= (1, 10):
-            is_authenticated = request.user.is_authenticated
-        else:
+        if callable(request.user.is_authenticated):
             is_authenticated = request.user.is_authenticated()
+        else:
+            is_authenticated = request.user.is_authenticated
         if is_authenticated:
             username = request.user.get_username()
             if username != remote_username:


### PR DESCRIPTION
In Django 2.0, support for user.is_authenticated() was removed in favor of the user.is_authenticated property that was introduced in Django 1.10 (https://code.djangoproject.com/ticket/25847)

This results in a 'bool' object is not callable error when using HijackRemoteUserMiddleware.

I'm not entirely sure this is the absolute best fix for the issue, but I thought it couldn't hurt to try to offer a solution while bringing up the issue.