### PR TITLE
signals: send both the user instances and user IDs for bw compatibility

### DIFF
--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -65,7 +65,11 @@ def release_hijack(request):
         request.session.pop('is_hijacked_user', None)
         request.session.pop('display_hijack_warning', None)
     request.session.modified = True
-    hijack_ended.send(sender=None, hijacker_id=hijacker.pk, hijacked_id=hijacked.pk, request=request)
+    hijack_ended.send(
+            sender=None, request=request,
+            hijacker=hijacker, hijacked=hijacked,
+            # send IDs for backward compatibility
+            hijacker_id=hijacker.pk, hijacked_id=hijacked.pk)
     return redirect_to_next(request, default_url=hijack_settings.HIJACK_LOGOUT_REDIRECT_URL)
 
 
@@ -127,7 +131,11 @@ def login_user(request, hijacked):
         # Actually log user in
         login(request, hijacked)
 
-    hijack_started.send(sender=None, hijacker_id=hijacker.pk, hijacked_id=hijacked.pk, request=request)  # Send official, documented signal
+    hijack_started.send(
+            sender=None, request=request,
+            hijacker=hijacker, hijacked=hijacked,
+            # send IDs for backward compatibility
+            hijacker_id=hijacker.pk, hijacked_id=hijacked.pk)
     request.session['hijack_history'] = hijack_history
     request.session['is_hijacked_user'] = True
     request.session['display_hijack_warning'] = True

--- a/hijack/signals.py
+++ b/hijack/signals.py
@@ -1,4 +1,5 @@
 from django.dispatch import Signal
 
-hijack_started = Signal(providing_args=['hijacker_id', 'hijacked_id', 'request'])
-hijack_ended = Signal(providing_args=['hijacker_id', 'hijacked_id', 'request'])
+hijack_started = Signal(providing_args=['hijacker_id', 'hijacked_id', 'request', 'hijacker', 'hijacked'])
+hijack_ended = Signal(providing_args=['hijacker_id', 'hijacked_id', 'request', 'hijacker', 'hijacked'])
+

--- a/hijack/tests/test_hijack.py
+++ b/hijack/tests/test_hijack.py
@@ -317,11 +317,15 @@ class HijackTests(BaseHijackTests):
     def test_signals(self):
         received_signals = []
 
-        def hijack_started_receiver(sender, hijacker_id, hijacked_id, request, **kwargs):
+        def hijack_started_receiver(sender, hijacker_id, hijacked_id, request, hijacker, hijacked, **kwargs):
+            self.assertEqual(hijacker_id, hijacker.id)
+            self.assertEqual(hijacked_id, hijacked.id)
             received_signals.append('hijack_started_%d_%d' % (hijacker_id, hijacked_id))
         hijack_started.connect(hijack_started_receiver)
 
-        def hijack_ended_receiver(sender, hijacker_id, hijacked_id, request, **kwargs):
+        def hijack_ended_receiver(sender, hijacker_id, hijacked_id, request, hijacker, hijacked, **kwargs):
+            self.assertEqual(hijacker_id, hijacker.id)
+            self.assertEqual(hijacked_id, hijacked.id)
             received_signals.append('hijack_ended_%d_%d' % (hijacker_id, hijacked_id))
         hijack_ended.connect(hijack_ended_receiver)
 


### PR DESCRIPTION
I'm not sure why the signals are transporting the user *IDs* only, but it's quite a shame because it requires making new database requests within the signal receiver(s).

This PR adds the full user instances in signal parameters, while keeping the IDs for backward compatibility. Note that the argument order was unchanged so **old code will not break** with this patch.