### PR TITLE
Jinja support and modified _render_hijack_notification.

### DIFF
--- a/hijack/templatetags/hijack_tags.py
+++ b/hijack/templatetags/hijack_tags.py
@@ -3,10 +3,10 @@ from django import template
 from django.utils.safestring import mark_safe
 from django.template.loader import render_to_string
 from compat import import_string
-
 from hijack import settings as hijack_settings
 
 register = template.Library()
+
 
 
 @register.filter
@@ -23,11 +23,12 @@ def hijack_notification(context):
     return _render_hijack_notification(request)
 
 
-def _render_hijack_notification(request):
-    if hijack_settings.HIJACK_USE_BOOTSTRAP:
-        template_name = 'hijack/notifications_bootstrap.html'
-    else:
-        template_name = 'hijack/notifications.html'
+def _render_hijack_notification(request, template_name=None):
+    if template_name is None:
+        if hijack_settings.HIJACK_USE_BOOTSTRAP:
+            template_name = 'hijack/notifications_bootstrap.html'
+        else:
+            template_name = 'hijack/notifications.html'
     ans = ''
     if request is not None and all([
         hijack_settings.HIJACK_DISPLAY_WARNING,
@@ -51,3 +52,11 @@ def can_hijack(hijacker, hijacked):
 @register.filter
 def is_hijacked(request):
     return request.session.get('is_hijacked_user', False)
+
+try:
+    from django_jinja import library
+    @library.filter
+    def jinja_hijack_notification(request, template_name=None):
+        return _render_hijack_notification(request, template_name)
+except ImportError:
+    pass


### PR DESCRIPTION
1. `_render_hijack_notification` comes with `template_name` as an new keyword argument.
2. Jinja support: A new filter named `jinja_hijack_notification` was introduced. It takes a request and an optional template_name.