### PR TITLE
Fixed Django 2.1 compatibility

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 === (ongoing) ===
 - Django 2.1 Support (#173)
-- `redirect_to_next` helper now passes the ALLOWED_HOSTS setting to django's internal `is_safe_url` for Django 1.11 and higher.
+- Django 1.11 and higher: `redirect_to_next` helper now passes the request host to django's `is_safe_url` util's allowed_hosts parameter.
 
 == (2.1.6) ==
 - Add Slovak and Russian localization

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 === (ongoing) ===
--
+- Django 2.1 Support (#173)
+- `redirect_to_next` helper now passes the ALLOWED_HOSTS setting to django's internal `is_safe_url` for Django 1.11 and higher.
 
 == (2.1.6) ==
 - Add Slovak and Russian localization

--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import contextlib
 import django
-from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.models import update_last_login
 from django.contrib.auth.signals import user_logged_in
@@ -150,7 +149,7 @@ def redirect_to_next(request, default_url=hijack_settings.HIJACK_LOGIN_REDIRECT_
     # is_safe_url's allowed_hosts keyword was added in Django 1.11, and became required in 2.1:
     is_safe_url_kwargs = {}
     if django.VERSION >= (1, 11):
-        is_safe_url_kwargs['allowed_hosts'] = settings.ALLOWED_HOSTS
+        is_safe_url_kwargs['allowed_hosts'] = {request.get_host()}
     if not is_safe_url(redirect_to, **is_safe_url_kwargs):
         redirect_to = default_url
     return HttpResponseRedirect(resolve_url(redirect_to))

--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import contextlib
+import django
+from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.models import update_last_login
 from django.contrib.auth.signals import user_logged_in
@@ -145,6 +147,10 @@ def login_user(request, hijacked):
 
 def redirect_to_next(request, default_url=hijack_settings.HIJACK_LOGIN_REDIRECT_URL):
     redirect_to = request.GET.get('next', '')
-    if not is_safe_url(redirect_to):
+    # is_safe_url's allowed_hosts keyword was added in Django 1.11, and became required in 2.1:
+    is_safe_url_kwargs = {}
+    if django.VERSION >= (1, 11):
+        is_safe_url_kwargs['allowed_hosts'] = settings.ALLOWED_HOSTS
+    if not is_safe_url(redirect_to, **is_safe_url_kwargs):
         redirect_to = default_url
     return HttpResponseRedirect(resolve_url(redirect_to))

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27}-django{18,19,110,111}
-    py{35,36}-django{18,19,110,111,20}
+    py{35,36}-django{18,19,110,111,20,21}
 
 [testenv]
 deps =
@@ -12,6 +12,7 @@ deps =
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
 
 commands =
     pip freeze


### PR DESCRIPTION
Hello,

As mentioned in #173, Django 2.1 now requires allowed_hosts when calling the internal django util `http.is_safe_url`. I set it to `{request.get_host()}`, as that's how I observed a few other libraries and the django test suite using it. This change affects all Django versions >= 1.11, as that was the first version to accept the allowed_hosts parameter.

I don't think any new tests need to be written for this, but maybe a new HIJACK_REDIRECT_HOSTS setting could be added for customizing it, if someone wants that.

Thanks,
Phillip Marshall